### PR TITLE
Adding ARM support

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: asdf_plugin_test
+      - name: sopstool latest
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: asdf-vm/actions/plugin-test@v1.0.0
+        uses: asdf-vm/actions/plugin-test@v1
         with:
           command: sopstool version

--- a/bin/install
+++ b/bin/install
@@ -34,14 +34,14 @@ install() {
   local bin_path="${install_path}/sopstool"
 
   local download_url
-  download_url="https://github.com/ibotta/sopstool/releases/download/${version}/sopstool_${platform}.tar.gz"
+  download_url="https://github.com/ibotta/sopstool/releases/download/${version}/sopstool_${platform}_${arch}.tar.gz"
 
   mkdir -p "${install_path}"
 
   cd ${tmp_dir}
   echo "Downloading sopstool from ${download_url}"
-  curl -sL "$download_url" -o "${tmp_dir}/sopstool_${platform}_${version}.tar.gz"
-  tar -xzf ${tmp_dir}/sopstool_${platform}_${version}.tar.gz
+  curl -sL "$download_url" -o "${tmp_dir}/sopstool_${platform}_${arch}_${version}.tar.gz"
+  tar -xzf ${tmp_dir}/sopstool_${platform}_${arch}_${version}.tar.gz
   mv ${tmp_dir}/sopstool ${bin_path}
   chmod +x "${bin_path}"
 }

--- a/bin/install
+++ b/bin/install
@@ -6,7 +6,14 @@ set -euo pipefail
 [[ -z ${ASDF_INSTALL_VERSION} ]] && echo "ASDF_INSTALL_VERSION is required" && exit 1
 [[ -z ${ASDF_INSTALL_PATH} ]] && echo "ASDF_INSTALL_PATH is required" && exit 1
 [[ ${ASDF_INSTALL_TYPE} != version ]] && echo "install type '${ASDF_INSTALL_TYPE}' is not supported." && exit 1
-[[ $(uname -m) != x86_64 ]] && echo "Sorry i386 (32bit arch) is not supported." && exit 1
+
+arch="$(uname -m)"
+# Remap names to match GitHub releases.
+[[ $arch = "aarch64" ]] && arch="arm64"
+[[ $arch = "x86_64" ]] && arch="amd64"
+
+supported_archs=("amd64" "arm64")
+[[ ! " ${supported_archs[*]} " =~ ${arch} ]] && echo "Sorry, $arch is not supported." && exit 1
 
 platform="$(uname)"
 if [[  ! (${platform} == Linux || ${platform} == Darwin) ]]; then


### PR DESCRIPTION
@physik932 is adding M1/ARM support to `sopstool` and this will support installing those builds via `asdf`.

https://github.com/Ibotta/sopstool/pull/46